### PR TITLE
Support configuration for any backend

### DIFF
--- a/README.md
+++ b/README.md
@@ -17,6 +17,7 @@ only partially implemented.
 * Pluggable backends to support different equipment
   * Support: Junox MX, Force10 switch (etherscale), Dell Powerconnect
   * DUD backend for easy testing
+  * Any custom Python backend
 * Easy development of new backends
 * Easy creation of NML topology from short-hand topology specification
 * Topology aggregation and path finding to do multi-domain circuit creation

--- a/opennsa/config.py
+++ b/opennsa/config.py
@@ -330,7 +330,7 @@ def readVerifyConfig(cfg):
             raise ConfigurationError('Can only have one backend named "%s"' % name)
 
         if backend_type in (BLOCK_DUD, BLOCK_JUNIPER_EX, BLOCK_JUNIPER_VPLS, BLOCK_JUNOSMX, BLOCK_FORCE10, BLOCK_BROCADE,
-                            BLOCK_DELL, BLOCK_NCSVPN, BLOCK_PICA8OVS, BLOCK_OESS, BLOCK_JUNOSSPACE, BLOCK_JUNOSEX,  'asyncfail'):
+                            BLOCK_DELL, BLOCK_NCSVPN, BLOCK_PICA8OVS, BLOCK_OESS, BLOCK_JUNOSSPACE, BLOCK_JUNOSEX,  'asyncfail', 'backend'):
             backend_conf = dict( cfg.items(section) )
             backend_conf['_backend_type'] = backend_type
             backends[name] = backend_conf
@@ -338,4 +338,3 @@ def readVerifyConfig(cfg):
     vc['backend'] = backends
 
     return vc
-

--- a/opennsa/config.py
+++ b/opennsa/config.py
@@ -37,6 +37,7 @@ BLOCK_JUNOSMX    = 'junosmx'
 BLOCK_JUNOSEX    = 'junosex'
 BLOCK_JUNOSSPACE = 'junosspace'
 BLOCK_OESS       = 'oess'
+BLOCK_CUSTOM_BACKEND = 'backend'
 
 # service block
 NETWORK_NAME     = 'network'     # mandatory
@@ -330,7 +331,8 @@ def readVerifyConfig(cfg):
             raise ConfigurationError('Can only have one backend named "%s"' % name)
 
         if backend_type in (BLOCK_DUD, BLOCK_JUNIPER_EX, BLOCK_JUNIPER_VPLS, BLOCK_JUNOSMX, BLOCK_FORCE10, BLOCK_BROCADE,
-                            BLOCK_DELL, BLOCK_NCSVPN, BLOCK_PICA8OVS, BLOCK_OESS, BLOCK_JUNOSSPACE, BLOCK_JUNOSEX,  'asyncfail', 'backend'):
+                            BLOCK_DELL, BLOCK_NCSVPN, BLOCK_PICA8OVS, BLOCK_OESS, BLOCK_JUNOSSPACE, BLOCK_JUNOSEX,
+                            BLOCK_CUSTOM_BACKEND, 'asyncfail'):
             backend_conf = dict( cfg.items(section) )
             backend_conf['_backend_type'] = backend_type
             backends[name] = backend_conf

--- a/opennsa/setup.py
+++ b/opennsa/setup.py
@@ -4,6 +4,7 @@ High-level functionality for creating clients and services in OpenNSA.
 import os
 import hashlib
 import datetime
+import importlib
 
 from twisted.python import log
 from twisted.web import resource, server
@@ -72,6 +73,14 @@ def setupBackend(backend_cfg, network_name, nrm_ports, parent_requester):
         from opennsa.backends import oess
         BackendConstructer = oess.OESSBackend
 
+    elif backend_type == config.BLOCK_CUSTOM_BACKEND:
+        module_name = backend_cfg.pop('module')
+        try:
+            module = importlib.import_module(module_name)
+            BackendConstructer = module.Backend
+        except Exception as e:
+            log.msg('Failed to load backend {}:\n{}'.format(module_name, e))
+            raise config.ConfigurationError('Failed to load backend')
     else:
         raise config.ConfigurationError('No backend specified')
 


### PR DESCRIPTION
When building a new backend that is plugged into OpenNSA at runtime, it is
useful to configure that backend with the OpenNSA config file.

This patch adds the `backend` backend type the set of backend sections in the
configuration, so that any custom backend gets it's configuration passed in.