### PR TITLE
Adding json content-type

### DIFF
--- a/opennsa/protocols/rest/resource.py
+++ b/opennsa/protocols/rest/resource.py
@@ -131,6 +131,7 @@ class P2PBaseResource(resource.Resource):
             payload = json.dumps(res) + RN
 
             request.setResponseCode(200)
+            request.setHeader("Content-Type", 'application/json')
             request.write(payload)
             request.finish()
 
@@ -280,7 +281,7 @@ class P2PConnectionResource(resource.Resource):
             d = yield conn2dict(conn)
 
             payload = json.dumps(d) + RN
-            _finishRequest(request, 200, payload)
+            _finishRequest(request, 200, payload, {'Content-Type': 'application/json'})
 
         def noConnection(err):
             payload = 'No connection with id %s' % self.connection_id


### PR DESCRIPTION
Adds "application/json" content type to responses, to make it easier to consume in e.g. JAX-B java clients.