### PR TITLE
Added ERO support to the OpenNSA CLI.

### DIFF
--- a/onsa
+++ b/onsa
@@ -169,7 +169,7 @@ def doMain():
             if bandwidth is None:
                 raise usage.UsageError('Bandwidth is not defined')
 
-            bandwidth = config.subOptions[options.BANDWIDTH] or defaults.get(options.BANDWIDTH)
+            ero = config.subOptions[options.ERO] or defaults.get(options.BANDWIDTH)
 
         if config.subCommand in ('provision', 'release', 'terminate') and connection_id is None:
             raise usage.UsageError('Connection ID is not defined')
@@ -187,16 +187,16 @@ def doMain():
     # start over on commands, now we do the actual dispatch
 
     if config.subCommand == 'reserve':
-        yield commands.reserve(client, nsi_header, source_stp, dest_stp, start_time, end_time, bandwidth, connection_id, global_id)
+        yield commands.reserve(client, nsi_header, source_stp, dest_stp, start_time, end_time, bandwidth, ero, connection_id, global_id)
 
     elif config.subCommand == 'reserveonly':
-        yield commands.reserveonly(client, nsi_header, source_stp, dest_stp, start_time, end_time, bandwidth, connection_id, global_id)
+        yield commands.reserveonly(client, nsi_header, source_stp, dest_stp, start_time, end_time, bandwidth, ero, connection_id, global_id)
 
     elif config.subCommand == 'reserveprovision':
-        yield commands.reserveprovision(client, nsi_header, source_stp, dest_stp, start_time, end_time, bandwidth, connection_id, global_id, notification_wait)
+        yield commands.reserveprovision(client, nsi_header, source_stp, dest_stp, start_time, end_time, bandwidth, ero, connection_id, global_id, notification_wait)
 
     elif config.subCommand == 'rprt':
-        yield commands.rprt(client, nsi_header, source_stp, dest_stp, start_time, end_time, bandwidth, connection_id, global_id)
+        yield commands.rprt(client, nsi_header, source_stp, dest_stp, start_time, end_time, bandwidth, ero, connection_id, global_id)
 
     elif config.subCommand == 'reservecommit':
         yield commands.reservecommit(client, nsi_header, connection_id)

--- a/opennsa/aggregator.py
+++ b/opennsa/aggregator.py
@@ -747,7 +747,7 @@ class Aggregator:
             dest_stp = nsa.STP(c.dest_network, c.dest_port, c.dest_label)
 
             schedule = nsa.Schedule(c.start_time, c.end_time)
-            sd = nsa.Point2PointService(source_stp, dest_stp, c.bandwidth, cnt.BIDIRECTIONAL, False, None)
+            sd = nsa.Point2PointService(source_stp, dest_stp, c.bandwidth, cnt.BIDIRECTIONAL, False, None, None)
 
             criteria = nsa.QueryCriteria(c.revision, schedule, sd, children)
 

--- a/opennsa/cli/options.py
+++ b/opennsa/cli/options.py
@@ -34,6 +34,7 @@ DEST_STP        = 'dest'
 BANDWIDTH       = 'bandwidth'
 START_TIME      = 'starttime'
 END_TIME        = 'endtime'
+ERO             = 'ero'
 
 TLS             = config.TLS
 KEY             = config.KEY

--- a/opennsa/cli/parser.py
+++ b/opennsa/cli/parser.py
@@ -26,6 +26,7 @@
 # -a start time
 # -e end time
 # -b bandwidth (megabits)
+# -0 ero
 
 # -j security attributes
 # -l certificate (signed public key)
@@ -40,7 +41,7 @@
 # -z (skip) verify certificate (default is to verify)
 
 # free switches
-# 0-9
+# 1-9
 
 # Not all commands will accept all flags and some flags are mutally exclusive
 
@@ -115,6 +116,9 @@ class SecurityAttributeOptions(usage.Options):
 class BandwidthOption(usage.Options):
     optParameters = [ [ options.BANDWIDTH, 'b', None, 'Bandwidth (Megabits)'] ]
 
+class EroOption(usage.Options):
+    optParameters = [ [ options.ERO, '0', None, 'ERO list'] ]
+
 class PublicKeyOption(usage.Options):
     optParameters = [ [ options.CERTIFICATE, 'l', None, 'Certificate path' ] ]
 
@@ -163,7 +167,7 @@ class ProvisionOptions(NetworkCommandOptions, NotificationWaitFlag):
     pass
 
 
-class ReserveOptions(NetworkCommandOptions, SourceSTPOption, DestSTPOption, StartTimeOption, EndTimeOption, BandwidthOption):
+class ReserveOptions(NetworkCommandOptions, SourceSTPOption, DestSTPOption, StartTimeOption, EndTimeOption, BandwidthOption, EroOption):
 
     def postOptions(self):
         NetworkCommandOptions.postOptions(self)

--- a/opennsa/nsa.py
+++ b/opennsa/nsa.py
@@ -376,7 +376,7 @@ class Schedule(object):
 
 class Point2PointService(object):
 
-    def __init__(self, source_stp, dest_stp, capacity, directionality=BIDIRECTIONAL, symmetric=None, ero=None, parameters=None):
+    def __init__(self, source_stp, dest_stp, capacity, directionality=BIDIRECTIONAL, symmetric=False, ero=None, parameters=None):
 
         if directionality is None:
             raise error.MissingParameterError('directionality must be defined, must not be None')

--- a/opennsa/protocols/nsi2/bindings/p2pservices.py
+++ b/opennsa/protocols/nsi2/bindings/p2pservices.py
@@ -71,7 +71,7 @@ class P2PServiceBaseType(object):
         ET.SubElement(r, 'sourceSTP').text = self.sourceSTP
         ET.SubElement(r, 'destSTP').text = self.destSTP
         if self.ero is not None:
-            ET.SubElement(r, 'ero').extend( [ e.xml('ero') for e in self.ero ] )
+            ET.SubElement(r, 'ero').extend( [ e.xml('orderedSTP') for e in self.ero ] )
         if self.parameter is not None:
             for p in self.parameter:
                 ET.SubElement(r, 'parameter',  attrib={'type': p.type_}).text = p.value


### PR DESCRIPTION
Added -0 option to accept a list of ordered STP to add to the NSI ERO element in the reserve request.  For example, this ERO option will force a path from PacificWave to CERN to transit through Starlight and MOXY to Netherlight.

-0 "sttlwa.pacificwave.net:2016:topology:icair-grp,canarie.ca:2017:topology:ANA1"

This will result in the following XML element to be added to the reserve request:

```
<soap:Envelope xmlns:ctypes="http://schemas.ogf.org/nsi/2013/12/connection/types" xmlns:header="http://schemas.ogf.org/nsi/2013/12/framework/headers" xmlns:ns2="http://nordu.net/namespaces/2013/12/gnsbod" xmlns:p2psrv="http://schemas.ogf.org/nsi/2013/12/services/point2point" xmlns:soap="http://schemas.xmlsoap.org/soap/envelope/">
   <soap:Header>
      <header:nsiHeader>
         <protocolVersion>application/vnd.ogf.nsi.cs.v2.provider+soap</protocolVersion>
         <correlationId>urn:uuid:2d085cf8-0fc3-11ea-9e3a-28cfe91ccb5d</correlationId>
         <requesterNSA>urn:ogf:network:canada.eh:2016:nsa:requester</requesterNSA>
         <providerNSA>urn:ogf:network:es.net:2013:nsa:nsi-aggr-west</providerNSA>
         <replyTo>https://sense-rm.es.net:8000/NSI/services/RequesterService2</replyTo>
         <ns2:ConnectionTrace>
            <Connection index="0">urn:ogf:network:canada.eh:2016:nsa:requester:1</Connection>
         </ns2:ConnectionTrace>
      </header:nsiHeader>
   </soap:Header>
   <soap:Body>
      <ctypes:reserve>
         <globalReservationId>urn:uuid:6e1f288a-5a26-4ad8-a9bc-eb91785cee15</globalReservationId>
         <description>Test Connection</description>
         <criteria version="0">
            <schedule>
               <startTime>2019-11-20T11:00:00+00:00</startTime>
               <endTime>2019-11-20T11:30:00+00:00</endTime>
            </schedule>
            <serviceType>http://services.ogf.org/nsi/2013/12/descriptions/EVTS.A-GOLE</serviceType>
            <p2psrv:p2ps>
               <capacity>100</capacity>
               <directionality>Bidirectional</directionality>
               <symmetricPath>false</symmetricPath>
               <sourceSTP>urn:ogf:network:snvaca.pacificwave.net:2016:topology:irnc-dtn01.snvaca?vlan=3988</sourceSTP>
               <destSTP>urn:ogf:network:netherlight.net:2013:production7:cern-1?vlan=3988</destSTP>
               <ero>
                  <orderedSTP order="0">
                     <stp>urn:ogf:network:sttlwa.pacificwave.net:2016:topology:icair-grp</stp>
                  </orderedSTP>
                  <orderedSTP order="1">
                     <stp>urn:ogf:network:canarie.ca:2017:topology:ANA1</stp>
                  </orderedSTP>
               </ero>
            </p2psrv:p2ps>
         </criteria>
      </ctypes:reserve>
   </soap:Body>
</soap:Envelope>
```

This change was functionally tested on the AutomatedGOLE with the OpenNSA CLI issuing requests to the ESnet and Starlight aggregators.  OpenNSA was tested as n NSA on PacficWave  to verify correct behaviours.

No clue how to write or run automated tests in python.  Perhaps a how-to so newbies like me could at least run the tests?