### PR TITLE
Removed necessity for --squash

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -7,5 +7,5 @@ clean:
 	find . -name "*.pyc"|xargs rm
 
 docker-build:
-	docker build -t opennsa --squash docker
+	docker build -t opennsa docker
 

--- a/docker/Dockerfile
+++ b/docker/Dockerfile
@@ -10,37 +10,40 @@ ENV GIT_REPO https://github.com/NORDUnet/opennsa
 ENV USER opennsa
 
 
-# --- Base image ---
-# Update and install dependencies
-# pip to install twistar service-identity pyasn1
-# pyasn1 and crypto is needed for ssh backends
-RUN apt-get update && apt-get install -y git-core python3 python3-twisted-bin python3-openssl python3-psycopg2 python3-pip python3-crypto python3-dateutil
-
-RUN pip3 install twistar service-identity pyasn1
-
-
 # -- User setup --
 RUN adduser --disabled-password --gecos 'OpenNSA user' $USER
 
 
-# -- Install OpenNSA --
-USER $USER
-WORKDIR /home/$USER
-
-RUN echo git clone $GIT_REPO
-RUN git clone $GIT_REPO
-
+# --- Base image ---
+# Update and install dependencies
+# pip to install twistar service-identity pyasn1
+# pyasn1 and crypto is needed for ssh backends
+RUN apt update \
+ && apt install -y \
+    git-core \
+    python3 \
+    python3-twisted-bin \
+    python3-openssl \
+    python3-psycopg2 \
+    python3-pip \
+    python3-crypto \
+    python3-dateutil \
+ && pip3 install \
+    twistar \
+    service-identity \
+    pyasn1 \
+# -- Instal OpenNSA --
+ && echo git clone $GIT_REPO \
+ && su - $USER -c "git clone $GIT_REPO" \
 # -- Cleanup --
-# With --squash this makes the image go from 476 to 164 mb
-USER root
-RUN apt-get remove -y python3-pip git
-RUN apt-get -y clean
-RUN apt-get -y autoclean
-RUN apt-get -y autoremove
+ && apt remove -y \
+    git-core \
+    python3-pip \
+ && apt autoremove -y \
+ && rm -rf /var/lib/apt/lists/*
 
 
 # -- Switch to OpenNSA directory --
-
 USER $USER
 WORKDIR /home/$USER/opennsa
 


### PR DESCRIPTION
Grouped install and removals so that it doesn't increase the size of the final image. It is currently at 178MB without using sqash