### PR TITLE
Proxied setup support

### DIFF
--- a/datafiles/opennsa.conf
+++ b/datafiles/opennsa.conf
@@ -16,6 +16,9 @@
 # host=example.org
 # port=9443
 
+## in a proxied setup specify base_url
+# base_url=https://opennsa.example.domain/
+
 ## security settings
 
 #tls=true # defaults to true

--- a/opennsa/config.py
+++ b/opennsa/config.py
@@ -316,6 +316,16 @@ class Config(object):
             vc[BASE_URL] = None
 
         try:
+            vc[KEY] = cfg.get(BLOCK_SERVICE, KEY)
+        except configparser.NoOptionError:
+            vc[KEY] = None
+
+        try:
+            vc[CERTIFICATE] = cfg.get(BLOCK_SERVICE, CERTIFICATE)
+        except configparser.NoOptionError:
+            vc[CERTIFICATE] = None
+
+        try:
             policies = cfg.get(BLOCK_SERVICE, POLICY).split(',')
             for policy in policies:
                 if not policy in (cnt.REQUIRE_USER, cnt.REQUIRE_TRACE, cnt.AGGREGATOR, cnt.ALLOW_HAIRPIN):
@@ -356,18 +366,19 @@ class Config(object):
         # tls
         if vc[TLS]:
             try:
-                hostkey = cfg.get(BLOCK_SERVICE, KEY)
-                hostcert = cfg.get(BLOCK_SERVICE, CERTIFICATE)
-
-                if not os.path.exists(hostkey):
+                if not vc[KEY]:
                     raise ConfigurationError(
-                        'Specified hostkey does not exist (%s)' % hostkey)
-                if not os.path.exists(hostcert):
+                        'must specify a key when TLS is enabled')
+                elif not os.path.exists(vc[KEY]):
                     raise ConfigurationError(
-                        'Specified hostcert does not exist (%s)' % hostcert)
+                        'Specified key does not exist (%s)' % vc[KEY])
 
-                vc[KEY] = hostkey
-                vc[CERTIFICATE] = hostcert
+                if not vc[CERTIFICATE]:
+                    raise ConfigurationError(
+                        'must specify a certificate when TLS is enabled')
+                elif not os.path.exists(vc[CERTIFICATE]):
+                    raise ConfigurationError(
+                        'Specified certificate does not exist (%s)' % vc[CERTIFICATE])
 
                 try:
                     allowed_hosts_cfg = cfg.get(BLOCK_SERVICE, ALLOWED_HOSTS)

--- a/opennsa/config.py
+++ b/opennsa/config.py
@@ -44,6 +44,7 @@ LOG_FILE = 'logfile'
 HOST = 'host'
 PORT = 'port'
 TLS = 'tls'
+BASE_URL = 'base_url'
 REST = 'rest'
 NRM_MAP_FILE = 'nrmmap'
 PEERS = 'peers'
@@ -308,6 +309,11 @@ class Config(object):
         vc[HOST] = cfg.get(BLOCK_SERVICE, HOST, fallback=None)
         vc[TLS] = cfg.getboolean(BLOCK_SERVICE, TLS, fallback=DEFAULT_TLS)
         vc[PORT] = cfg.getint(BLOCK_SERVICE, PORT, fallback=DEFAULT_TLS_PORT if vc[TLS] else DEFAULT_TCP_PORT)
+
+        try:
+            vc[BASE_URL] = cfg.get(BLOCK_SERVICE, BASE_URL)
+        except configparser.NoOptionError:
+            vc[BASE_URL] = None
 
         try:
             policies = cfg.get(BLOCK_SERVICE, POLICY).split(',')

--- a/opennsa/setup.py
+++ b/opennsa/setup.py
@@ -100,6 +100,7 @@ def setupBackend(backend_cfg, network_name, nrm_ports, parent_requester):
 def setupTLSContext(vc):
     # ssl/tls contxt
     if vc[config.TLS]:
+        log.message('setup for full client/server TLS mode')
         from opennsa.opennsaTlsContext import opennsa2WayTlsContext
         ctx_factory = opennsa2WayTlsContext(
             vc[config.KEY], vc[config.CERTIFICATE], vc[config.CERTIFICATE_DIR], vc[config.VERIFY_CERT])
@@ -110,11 +111,13 @@ def setupTLSContext(vc):
                 'certdir value {} is not a directory'.format(vc[config.CERTIFICATE_DIR]))
         if vc[config.KEY] and vc[config.CERTIFICATE]:
             # enable client authentication even when not in TLS mode
+            log.message('setup for client TLS mode with client authentication')
             from opennsa.opennsaTlsContext import opennsa2WayTlsContext
             ctx_factory = opennsa2WayTlsContext(
                 vc[config.KEY], vc[config.CERTIFICATE], vc[config.CERTIFICATE_DIR], vc[config.VERIFY_CERT])
         else:
             from opennsa.opennsaTlsContext import opennsaTlsContext
+            log.message('setup for client TLS mode without client authentication')
             ctx_factory = opennsaTlsContext(
                 vc[config.CERTIFICATE_DIR], vc[config.VERIFY_CERT])
     else:

--- a/opennsa/setup.py
+++ b/opennsa/setup.py
@@ -99,29 +99,16 @@ def setupBackend(backend_cfg, network_name, nrm_ports, parent_requester):
 
 def setupTLSContext(vc):
     # ssl/tls contxt
-    if vc[config.TLS]:
-        log.msg('setup for full client/server TLS mode')
+    if vc[config.KEY] and vc[config.CERTIFICATE]:
+        log.msg('setup full 2Way TLS context')
         from opennsa.opennsaTlsContext import opennsa2WayTlsContext
         ctx_factory = opennsa2WayTlsContext(
             vc[config.KEY], vc[config.CERTIFICATE], vc[config.CERTIFICATE_DIR], vc[config.VERIFY_CERT])
-    elif vc[config.CERTIFICATE_DIR]:
-        # create a context so we can verify https urls
-        if not os.path.isdir(vc[config.CERTIFICATE_DIR]):
-            raise config.ConfigurationError(
-                'certdir value {} is not a directory'.format(vc[config.CERTIFICATE_DIR]))
-        if vc[config.KEY] and vc[config.CERTIFICATE]:
-            # enable client authentication even when not in TLS mode
-            log.msg('setup for client TLS mode with client authentication')
-            from opennsa.opennsaTlsContext import opennsa2WayTlsContext
-            ctx_factory = opennsa2WayTlsContext(
-                vc[config.KEY], vc[config.CERTIFICATE], vc[config.CERTIFICATE_DIR], vc[config.VERIFY_CERT])
-        else:
-            from opennsa.opennsaTlsContext import opennsaTlsContext
-            log.msg('setup for client TLS mode without client authentication')
-            ctx_factory = opennsaTlsContext(
-                vc[config.CERTIFICATE_DIR], vc[config.VERIFY_CERT])
     else:
-        ctx_factory = None
+        from opennsa.opennsaTlsContext import opennsaTlsContext
+        log.msg('setup client TLS context without client authentication')
+        ctx_factory = opennsaTlsContext(
+            vc[config.CERTIFICATE_DIR], vc[config.VERIFY_CERT])
 
     return ctx_factory
 

--- a/opennsa/setup.py
+++ b/opennsa/setup.py
@@ -100,7 +100,7 @@ def setupBackend(backend_cfg, network_name, nrm_ports, parent_requester):
 def setupTLSContext(vc):
     # ssl/tls contxt
     if vc[config.TLS]:
-        log.message('setup for full client/server TLS mode')
+        log.msg('setup for full client/server TLS mode')
         from opennsa.opennsaTlsContext import opennsa2WayTlsContext
         ctx_factory = opennsa2WayTlsContext(
             vc[config.KEY], vc[config.CERTIFICATE], vc[config.CERTIFICATE_DIR], vc[config.VERIFY_CERT])
@@ -111,13 +111,13 @@ def setupTLSContext(vc):
                 'certdir value {} is not a directory'.format(vc[config.CERTIFICATE_DIR]))
         if vc[config.KEY] and vc[config.CERTIFICATE]:
             # enable client authentication even when not in TLS mode
-            log.message('setup for client TLS mode with client authentication')
+            log.msg('setup for client TLS mode with client authentication')
             from opennsa.opennsaTlsContext import opennsa2WayTlsContext
             ctx_factory = opennsa2WayTlsContext(
                 vc[config.KEY], vc[config.CERTIFICATE], vc[config.CERTIFICATE_DIR], vc[config.VERIFY_CERT])
         else:
             from opennsa.opennsaTlsContext import opennsaTlsContext
-            log.message('setup for client TLS mode without client authentication')
+            log.msg('setup for client TLS mode without client authentication')
             ctx_factory = opennsaTlsContext(
                 vc[config.CERTIFICATE_DIR], vc[config.VERIFY_CERT])
     else:


### PR DESCRIPTION
- in a proxied setup base_url is not just the combination of host+port, in this case use base_url to specify the outside endpoint
- even when TLS is not enabled make client authentication possible when a key and certificate are specified
- always try to find a key and certificate in the config so they can be used in client TLS mode with client authentication
- additional logging of wich TLS mode is being setup
