### PR TITLE
Minor enhancement to OESS backend to also include trunk ports

### DIFF
--- a/opennsa/backends/oess.py
+++ b/opennsa/backends/oess.py
@@ -185,7 +185,7 @@ def oess_query_vlan_availability(conn, sw, intf, vlan):
 
 @defer.inlineCallbacks
 def oess_get_switch_ports(conn, node):
-    query = 'services/data.cgi?action=get_node_interfaces&node=%s' % node
+    query = 'services/data.cgi?action=get_node_interfaces&node=%s&show_down=1&show_trunk=1' % node
     retval = yield http_query(conn, query)
     defer.returnValue(retval)
 


### PR DESCRIPTION
### Description of the change

This PR adds a minor enhancement to the OESS backend to get trunk ports and ports with status DOWN when getting the interfaces from a node. This is the default behavior when creating circuits through OESS UI. Thanks to @marcosfsch for finding this bug.

Without the proposed change, users may end up receiving the following error when creating circuits:

```
2022-08-24 22:26:04Z [opennsa.OESS] Error creating circuit: Incorrect Interface - interface xxx/yyy
```

The patch has been tested on FIU/AMPATH testing environment.