### PR TITLE
fix error with twistar lib on debian 12

### DIFF
--- a/CHANGELOG
+++ b/CHANGELOG
@@ -5,6 +5,7 @@ Future release
 --------------
 
 * Support for ERO on the client (no server side yet)
+* Fixed error with twistar on python 3.11 for Debian bookworm
 
 
 OpenNSA 3.0.1

--- a/docker/Dockerfile
+++ b/docker/Dockerfile
@@ -1,6 +1,6 @@
 # OpenNSA docker image
 
-FROM debian:stable-slim
+FROM debian:12-slim
 
 LABEL maintainer="Henrik Thostrup Jensen <htj@nordu.net>"
 

--- a/requirements.txt
+++ b/requirements.txt
@@ -1,5 +1,7 @@
 twisted>=21.2.0,<21.7.0
-twistar>=2.0
+# Workaround for issue on BerminInflector lib
+# https://github.com/NORDUnet/opennsa/issues/48
+https://github.com/amlight/twistar/archive/master.tar.gz#egg=twistar
 psycopg2>=2.9,<2.10 --no-binary psycopg2
 pyOpenSSL>=17.5.0
 python-dotenv>=0.19.0


### PR DESCRIPTION
Fix #48 

## Description of the change

This PR basically replaces `twistar` lib with a forked version made on Amlight to fix the re error on global flags. Please refer to PR https://github.com/amlight/twistar/pull/1 for more details and tests around that fix

Additionally, the base debian image was pinned to debian 12 to avoid surprises when a new stable version is released.

## Local tests

We have been using this version at Ampath.net NSI domain for a few days without surprises.